### PR TITLE
Fix UI qrc resource file paths

### DIFF
--- a/ui/graph_page.ui
+++ b/ui/graph_page.ui
@@ -14,7 +14,7 @@
    <string>Variable Graph</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="ddsmon.qrc">
+   <iconset resource="../ddsmon.qrc">
     <normaloff>:/images/monitor.png</normaloff>:/images/monitor.png</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -91,7 +91,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/player-pause.png</normaloff>:/images/player-pause.png</iconset>
          </property>
         </widget>
@@ -108,7 +108,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/player-rew.png</normaloff>:/images/player-rew.png</iconset>
          </property>
         </widget>
@@ -125,7 +125,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/player-ff.png</normaloff>:/images/player-ff.png</iconset>
          </property>
         </widget>
@@ -142,7 +142,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/player-next.png</normaloff>:/images/player-next.png</iconset>
          </property>
         </widget>
@@ -159,7 +159,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/flush.png</normaloff>:/images/flush.png</iconset>
          </property>
         </widget>
@@ -176,7 +176,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/scale.png</normaloff>:/images/scale.png</iconset>
          </property>
         </widget>
@@ -193,7 +193,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/plus.png</normaloff>:/images/plus.png</iconset>
          </property>
         </widget>
@@ -210,7 +210,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/trashcan.png</normaloff>:/images/trashcan.png</iconset>
          </property>
         </widget>
@@ -227,7 +227,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/save.png</normaloff>:/images/save.png</iconset>
          </property>
         </widget>
@@ -244,7 +244,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/printer.png</normaloff>:/images/printer.png</iconset>
          </property>
         </widget>
@@ -258,7 +258,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/tool.png</normaloff>:/images/tool.png</iconset>
          </property>
         </widget>
@@ -272,7 +272,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/player-eject.png</normaloff>:/images/player-eject.png</iconset>
          </property>
         </widget>
@@ -286,7 +286,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset resource="ddsmon.qrc">
+          <iconset resource="../ddsmon.qrc">
            <normaloff>:/images/download.png</normaloff>:/images/download.png</iconset>
          </property>
         </widget>
@@ -321,7 +321,7 @@
   <tabstop>ejectButton</tabstop>
  </tabstops>
  <resources>
-  <include location="ddsmon.qrc"/>
+  <include location="../ddsmon.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/graph_properties.ui
+++ b/ui/graph_properties.ui
@@ -14,7 +14,7 @@
    <string>Graph Properties</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="ddsmon.qrc">
+   <iconset resource="../ddsmon.qrc">
     <normaloff>:/images/tool.png</normaloff>:/images/tool.png</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
@@ -39,7 +39,7 @@
         <string>Close</string>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/close.png</normaloff>:/images/close.png</iconset>
        </property>
       </widget>
@@ -326,7 +326,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="ddsmon.qrc"/>
+  <include location="../ddsmon.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/log_page.ui
+++ b/ui/log_page.ui
@@ -14,7 +14,7 @@
    <string>Logs</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="ddsmon.qrc">
+   <iconset resource="../ddsmon.qrc">
     <normaloff>:/images/terminal.png</normaloff>:/images/terminal.png</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -41,7 +41,7 @@
         <string>Clear</string>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/edit-clear.png</normaloff>:/images/edit-clear.png</iconset>
        </property>
       </widget>
@@ -65,7 +65,7 @@
         <string>Print</string>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/print.png</normaloff>:/images/print.png</iconset>
        </property>
       </widget>
@@ -76,7 +76,7 @@
         <string>Save</string>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/filesave.png</normaloff>:/images/filesave.png</iconset>
        </property>
       </widget>
@@ -86,7 +86,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="ddsmon.qrc"/>
+  <include location="../ddsmon.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/main_window.ui
+++ b/ui/main_window.ui
@@ -14,7 +14,7 @@
    <string>DDS Monitor</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="ddsmon.qrc">
+   <iconset resource="../ddsmon.qrc">
     <normaloff>:/images/find.png</normaloff>:/images/find.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -77,7 +77,7 @@
   <widget class="QStatusBar" name="statusbar"/>
   <action name="actionNewTable">
    <property name="icon">
-    <iconset resource="ddsmon.qrc">
+    <iconset resource="../ddsmon.qrc">
      <normaloff>:/images/stock_data-new-table.png</normaloff>:/images/stock_data-new-table.png</iconset>
    </property>
    <property name="text">
@@ -86,7 +86,7 @@
   </action>
   <action name="actionNewPlot">
    <property name="icon">
-    <iconset resource="ddsmon.qrc">
+    <iconset resource="../ddsmon.qrc">
      <normaloff>:/images/monitor.png</normaloff>:/images/monitor.png</iconset>
    </property>
    <property name="text">
@@ -95,7 +95,7 @@
   </action>
  </widget>
  <resources>
-  <include location="ddsmon.qrc"/>
+  <include location="../ddsmon.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/recorder_dialog.ui
+++ b/ui/recorder_dialog.ui
@@ -14,7 +14,7 @@
    <string>DDS Data Recorder</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="ddsmon.qrc">
+   <iconset resource="../ddsmon.qrc">
     <normaloff>:/images/media-record.png</normaloff>:/images/media-record.png</iconset>
   </property>
   <property name="sizeGripEnabled">
@@ -487,7 +487,7 @@
         <string>Record</string>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/media-record.png</normaloff>:/images/media-record.png</iconset>
        </property>
       </widget>
@@ -498,7 +498,7 @@
         <string>Stop</string>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/media-playback-stop.png</normaloff>:/images/media-playback-stop.png</iconset>
        </property>
       </widget>
@@ -509,7 +509,7 @@
         <string>Close</string>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/close.png</normaloff>:/images/close.png</iconset>
        </property>
       </widget>
@@ -616,7 +616,7 @@ Columns</string>
   <tabstop>closeButton</tabstop>
  </tabstops>
  <resources>
-  <include location="ddsmon.qrc"/>
+  <include location="../ddsmon.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/table_page.ui
+++ b/ui/table_page.ui
@@ -95,7 +95,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/edit-clear.png</normaloff>:/images/edit-clear.png</iconset>
        </property>
       </widget>
@@ -115,7 +115,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/filter.png</normaloff>:/images/filter.png</iconset>
        </property>
       </widget>
@@ -135,7 +135,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/prevfuzzy.png</normaloff>:/images/prevfuzzy.png</iconset>
        </property>
        <property name="checkable">
@@ -161,7 +161,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/unlock.png</normaloff>:/images/unlock.png</iconset>
        </property>
       </widget>
@@ -181,7 +181,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/lock.png</normaloff>:/images/lock.png</iconset>
        </property>
       </widget>
@@ -201,7 +201,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/exportdoc.png</normaloff>:/images/exportdoc.png</iconset>
        </property>
       </widget>
@@ -221,7 +221,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/revert.png</normaloff>:/images/revert.png</iconset>
        </property>
       </widget>
@@ -241,7 +241,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/monitor_new.png</normaloff>:/images/monitor_new.png</iconset>
        </property>
       </widget>
@@ -261,7 +261,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/monitor_attach.png</normaloff>:/images/monitor_attach.png</iconset>
        </property>
       </widget>
@@ -281,7 +281,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/media-record.png</normaloff>:/images/media-record.png</iconset>
        </property>
       </widget>
@@ -358,7 +358,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="ddsmon.qrc">
+        <iconset resource="../ddsmon.qrc">
          <normaloff>:/images/exports.png</normaloff>:/images/exports.png</iconset>
        </property>
       </widget>
@@ -368,7 +368,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="ddsmon.qrc"/>
+  <include location="../ddsmon.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
The path to qrc file was never correctly set for new location, so opening files in qtcreator design page caused error messages.