### PR TITLE
Update for Current OpenDDS master and Minor CMake Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets Gui PrintSupport Svg OpenGL OPTIONAL_COMPONENTS ${qt_optional_components})
 
-if(${QWT_IS_LOCAL})
+if(QWT_IS_LOCAL)
   set(QWT_LIBRARY ${PROJECT_SOURCE_DIR}/qwt/lib/qwt$<$<CONFIG:DEBUG>:d>.lib)
   set(QWT_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/qwt/src)
 else()
@@ -120,8 +120,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 target_compile_options(monitor PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wall -Wextra -Wpedantic -Wno-unused -Wunused-parameter> $<$<CXX_COMPILER_ID:MSVC>: /W4>)
-
-add_dependencies(monitor OpenDDW)
 
 target_link_libraries(monitor
   OpenDDW

--- a/FindQwt.cmake
+++ b/FindQwt.cmake
@@ -42,18 +42,21 @@ FIND_PATH(QWT_INCLUDE_DIR NAMES qwt.h PATHS
   PATH_SUFFIXES qwt-qt5 qwt qwt6 qt5/qwt
 )
 
-IF (QWT_INCLUDE_DIR AND QWT_LIBRARY)
-  SET(QWT_FOUND TRUE)
-ENDIF (QWT_INCLUDE_DIR AND QWT_LIBRARY)
+if(QWT_INCLUDE_DIR AND QWT_LIBRARY)
+  set(Qwt_FOUND TRUE)
 
-IF (QWT_FOUND)
   FILE(READ ${QWT_INCLUDE_DIR}/qwt_global.h qwt_header)
   STRING(REGEX REPLACE "^.*QWT_VERSION_STR +\"([^\"]+)\".*$" "\\1" QWT_VERSION_STR "${qwt_header}")
-  IF (NOT QWT_FIND_QUIETLY)
+
+  if(NOT Qwt_FIND_QUIETLY)
     MESSAGE(STATUS "Found Qwt: ${QWT_LIBRARY} (${QWT_VERSION_STR})")
-  ENDIF (NOT QWT_FIND_QUIETLY)
-ELSE (QWT_FOUND)
-  IF (QWT_FIND_REQUIRED)
-    MESSAGE(FATAL_ERROR "Could not find Qwt")
-  ENDIF (QWT_FIND_REQUIRED)
-ENDIF (QWT_FOUND)
+  endif()
+else()
+  set(Qwt_FOUND FALSE)
+
+  if(Qwt_FIND_REQUIRED)
+    message(FATAL_ERROR "Could not find required Qwt")
+  elseif(NOT Qwt_FIND_QUIETLY)
+    message(STATUS "Could not find optional Qwt")
+  endif()
+endif()

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -53,7 +53,7 @@ DDSMonitorMainWindow::DDSMonitorMainWindow() :
     {
         // Prompt the user for the domain selection
         domainID = settings.value("domainID").toInt();
-        
+
         domainID = QInputDialog::getInt(
             this, "Join Domain", "Join DDS Domain:", domainID, -1, 232, 1, &ok);
     }
@@ -67,7 +67,8 @@ DDSMonitorMainWindow::DDSMonitorMainWindow() :
         // Join the DDS domain
         CommonData::m_ddsManager = std::make_unique<DDSManager>();
         m_participantPage = new ParticipantPage(mainTabWidget);
-        CommonData::m_ddsManager->joinDomain(domainID, "", [page = m_participantPage](const ParticipantInfo& info) {page->addParticipant(info); }, 
+        CommonData::m_ddsManager->joinDomain(domainID, "",
+            [page = m_participantPage](const ParticipantInfo& info) {page->addParticipant(info); },
             [page = m_participantPage](const ParticipantInfo& info) {page->removeParticipant(info); });
         m_publicationMonitor = std::make_unique<PublicationMonitor>();
         m_subscriptionMonitor = std::make_unique<SubscriptionMonitor>();
@@ -375,7 +376,11 @@ void DDSMonitorMainWindow::reportConfig() const
             //const uint16_t userMulicastPort = pb + (dg * domainID) + d2;
 
             std::cout << "\nDiscovery multicast:             "
-                      << rtpsInfo->default_multicast_group(domainID).to_addr().get_host_addr()
+                      << rtpsInfo->default_multicast_group(
+#if OPENDDS_VERSION_AT_LEAST(3, 27, 0)
+                        domainID).to_addr(
+#endif
+                        ).get_host_addr()
                       << ":"
                       << discoveryMulicastPort
                       //<< "\nDiscovery unicast:               "
@@ -438,7 +443,11 @@ void DDSMonitorMainWindow::reportConfig() const
         const OpenDDS::DCPS::TransportInst_rch transportInstance =
             transportConfig->instances_[i];
 
-        std::cout << transportInstance->dump_to_str(domainID) << "\n";
+        std::cout << transportInstance->dump_to_str(
+#if OPENDDS_VERSION_AT_LEAST(3, 27, 0)
+          domainID
+#endif
+        ) << "\n";
     }
 
 } // End DDSMonitorMainWindow::reportConfig

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -352,18 +352,18 @@ void DDSMonitorMainWindow::reportConfig() const
     if (discoveryMap.find(discoveryKey) != discoveryMap.end())
     {
         const OpenDDS::DCPS::Discovery_rch discoveryInfo = discoveryMap.at(discoveryKey);
-        const OpenDDS::RTPS::RtpsDiscovery* rtspInfo =
+        const OpenDDS::RTPS::RtpsDiscovery* rtpsInfo =
             dynamic_cast<const OpenDDS::RTPS::RtpsDiscovery*>
             (discoveryInfo.in());
 
         // Only care about RTPS for now
-        if (rtspInfo)
+        if (rtpsInfo)
         {
             // Ports are defined from RTPS discovery spec
-            const uint16_t pb = rtspInfo->pb(); // Port base [7400]
-            const uint16_t dg = rtspInfo->dg(); // Domain ID gain [250]
+            const uint16_t pb = rtpsInfo->pb(); // Port base [7400]
+            const uint16_t dg = rtpsInfo->dg(); // Domain ID gain [250]
             //const uint16_t pg = rtspInfo->pg(); // Participant ID gain [2]
-            const uint16_t d0 = rtspInfo->d0(); // Discovery multicast port offset [0]
+            const uint16_t d0 = rtpsInfo->d0(); // Discovery multicast port offset [0]
             //const uint16_t d1 = rtspInfo->d1(); // Discovery unicast port offset [10]
             //const uint16_t d2 = 1; // User data multicast port offset
             //const uint16_t d3 = 11; // User data unicast port offset
@@ -375,7 +375,7 @@ void DDSMonitorMainWindow::reportConfig() const
             //const uint16_t userMulicastPort = pb + (dg * domainID) + d2;
 
             std::cout << "\nDiscovery multicast:             "
-                      << rtspInfo->default_multicast_group().get_host_addr()
+                      << rtpsInfo->default_multicast_group(domainID).to_addr().get_host_addr()
                       << ":"
                       << discoveryMulicastPort
                       //<< "\nDiscovery unicast:               "
@@ -399,11 +399,11 @@ void DDSMonitorMainWindow::reportConfig() const
                       //<< "\nGUID interface:                  "
                       //<< rtspInfo->guid_interface()
                       << "\nSupports liveliness:             "
-                      << rtspInfo->supports_liveliness()
+                      << rtpsInfo->supports_liveliness()
                       << "\nResend period:                   "
-                      << rtspInfo->resend_period().to_dds_duration().sec
+                      << rtpsInfo->resend_period().to_dds_duration().sec
                       << "\nTTL:                             "
-                      << static_cast<int>(rtspInfo->ttl())
+                      << static_cast<int>(rtpsInfo->ttl())
                       //<< "\nPB:                              " << pb
                       //<< "\nDG:                              " << dg
                       //<< "\nPG:                              " << pg
@@ -438,7 +438,7 @@ void DDSMonitorMainWindow::reportConfig() const
         const OpenDDS::DCPS::TransportInst_rch transportInstance =
             transportConfig->instances_[i];
 
-        std::cout << transportInstance->dump_to_str() << "\n";
+        std::cout << transportInstance->dump_to_str(domainID) << "\n";
     }
 
 } // End DDSMonitorMainWindow::reportConfig

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(opendds-monitor-tests VERSION 0.0.1 LANGUAGES CXX)
 


### PR DESCRIPTION
- Updated OpenDDW submodule to include https://github.com/OpenDDS/OpenDDW/pull/18
- Updated transport code for current OpenDDS
- Fix warning on test's `cmake_minimum_required`
- Make `FindQwt.cmake` properly error when it can't find Qwt.