### PR TITLE
Prevent crash when opening new tab for topic with multiple partitions

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -213,7 +213,7 @@ void DDSMonitorMainWindow::on_topicTree_itemClicked(QTreeWidgetItem* item, int)
     if (!selectedPartition.isEmpty())
     {
         partitionInfo.name.length(1);
-        partitionInfo.name[0] = selectedPartition.toUtf8().data();
+        partitionInfo.name[0] = selectedPartition.toStdString().c_str();
     }
 
     topicInfo->subQos.partition = partitionInfo;


### PR DESCRIPTION
If a topic which is published in multiple partitions is clicked on the application crashes after selecting the partition.
This commit fixes this.
This was seen on a Windows Unicode build of OpenDDS