### PR TITLE
Dynamic data support for plotting, recording, and replaying/publishing

### DIFF
--- a/src/dds_data.h
+++ b/src/dds_data.h
@@ -26,7 +26,7 @@
 
 #include <memory>
 #include <string>
-
+#include <dds/DCPS/XTypes/TypeObject.h>
 
 class DDSManager;
 class OpenDynamicData;
@@ -244,6 +244,24 @@ public:
     static QVariant readValue(const QString& topicName,
                               const QString& memberName,
                               const unsigned int& index = 0);
+
+    /**
+    * @brief Get a dynamic data member's typeKind.
+    * @param[in] currentData The data sample of the topic (final level if nested).
+    * @param[in] memberId MemberId of interest.
+    * @return A OpenDDS::XTypes::TypeKind containing the member's typekind.
+    */
+    static OpenDDS::XTypes::TypeKind getMemberTypeKindById(const DDS::DynamicData_var& currentData,
+                                                           const DDS::MemberId memberId);
+
+    /**
+    * @brief Get a dynamic data member's memberId from its full name path.
+    * @param[in] currentData The data sample of the topic - this will be edited to point to the final level of a nested sample.
+    * @param[in] memberId The member's full path/name, including parents (ie with periods).
+    * @return A DDS::MemberId containing the member's ID.
+    */
+    static DDS::MemberId getNestedMemberAndIdByName(DDS::DynamicData_var& currentData,
+                                                    const QString& memberName);
 
     /**
      * @brief Delete all data samples for a specified topic.

--- a/src/table_page.cpp
+++ b/src/table_page.cpp
@@ -291,13 +291,14 @@ void TablePage::on_revertButton_clicked()
 void TablePage::on_publishButton_clicked()
 {
     const std::shared_ptr<OpenDynamicData> sample = m_tableModel->commitSample();
-    if (!sample)
-    {
-        return;
-    }
-
+    const DDS::DynamicData_var dynamicSample = m_tableModel->commitDynamicSample();
+  if (dynamicSample) {
+    m_topicReplayer->publishSample(dynamicSample);
+    revertButton->setEnabled(false);
+  } else if (sample) {
     m_topicReplayer->publishSample(sample);
     revertButton->setEnabled(false);
+  }
 }
 
 

--- a/src/topic_replayer.h
+++ b/src/topic_replayer.h
@@ -34,6 +34,7 @@ public:
      * @param[in] sample Publish this data sample.
      */
     void publishSample(const std::shared_ptr<OpenDynamicData> sample);
+    void publishSample(const DDS::DynamicData_var sample);
 
     /**
     * @brief Destructor for the DDS topic replayer.
@@ -56,6 +57,9 @@ private:
 
     /// The topic extensibility
     OpenDDS::DCPS::Extensibility m_extensibility;
+
+    /// A dynamic data writer for this topic
+    DDS::DataWriter_var m_dw;
 };
 
 #endif

--- a/src/topic_table_model.h
+++ b/src/topic_table_model.h
@@ -51,6 +51,7 @@ public:
      * @remarks The returned value is the user-edited sample data to publish.
      */
     const std::shared_ptr<OpenDynamicData> commitSample();
+    const DDS::DynamicData_var commitDynamicSample();
 
     /**
      * @brief Standard row count for table.
@@ -200,6 +201,7 @@ private:
      */
     bool populateSample(std::shared_ptr<OpenDynamicData> const sample,
                         DataRow *dataInfo);
+    bool populateSample(DDS::DynamicData_var const sample, DataRow *dataInfo);
 
     /// The table view using this model
     QTableView* m_tableView;


### PR DESCRIPTION
Currently the replayer/publisher for dynamic data still doesn't work, here are the issues I'm stuck on:
- DynamicData::set_*_value is returning RETCODE::UNSUPPORTED when trying to populate the cloned (and also original to check if just clone was failing) dynamicData sample, despite the get_*_value functions returning the correct values (ie correct memberId and datatypes). 
  - I'm not sure if I'm not accessing it properly and it's read-only or something, but I can't seem to figure it out.
- Trying to write the dynamic sample (even without trying to edit the sample values) to the dynamic data writer is giving a serialization error:
  - (42232|15776) WARNING: DynamicSample::serialized_size: DynamicDataBase::serialized_size failed!
  - (42232|15776) ERROR: DataWriterImpl::serialize_sample: failed to serialize sample data
  - I'm assuming this stems from me not setting up the data writer properly?

In case it's relevant, I'm using OpenDDS 3.28.1 (and have to locally comment out `#include <dds/DCPS/EncapsulationHeader.h>` in topic_replayer.cpp, and I have to change `DynamicMetaStruct::getValue(___ , OpenDDS::DCPS::TypeSupportImpl*)` to `DynamicMetaStruct::getValue(___ , const OpenDDS::DCPS::TypeSupportImpl*)` on my computer to run everything as a result), and I'm on Windows only. 

Disclaimer: I'm not a dev, hopefully this isn't attrocious.