### PR TITLE
Add Initial Qt6 Build Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,6 @@ jobs:
           cd build
           CMAKE_ARGS=""
           if [ '${{ runner.os }}' == 'macOS' ]; then
-            # CMAKE_ARGS+=" -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5"
             export QWT_DIR=$(brew --prefix qwt-qt5)
             CMAKE_ARGS+=" -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)"
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,10 @@ jobs:
           echo "MPC_ROOT=$GITHUB_WORKSPACE/MPC" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ACE_TAO/ACE/lib:$GITHUB_WORKSPACE/OpenDDS/lib" >> $GITHUB_ENV
           CONFIG_OPTIONS+=" --no-tests --std=c++17 --ipv6 --security"
-          if [ '${{ runner.os }}' == 'macOS' ]; then
+          if [ '${{ matrix.runner }}' == 'macos-13' ]; then
             CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@1.1"
+          else
+            CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@3.0"
           fi
           echo "CONFIG_OPTIONS=$CONFIG_OPTIONS" >> $GITHUB_ENV
           export COMPILER_VERSION=$(c++ --version 2>&1 | head -n 1)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,13 +221,15 @@ jobs:
         run: |-
           cmake -DBUILD_TYPE=debug -DVCPKG_INSTALLED_DIR=%VCPKG_INSTALLED_DIR% -DVCPKG_DEFAULT_TRIPLET=%VCPKG_DEFAULT_TRIPLET% -P BuildQwt.cmake
 
-      # Build opendds-monitor
-      - name: 'Set Up Problem Matcher (Windows)'
-        if: runner.os == 'Windows'
-        uses: ammaraskar/msvc-problem-matcher@0.3.0
+      # Set up problem matchers
       - name: 'Set Up Problem Matcher (Linux / macOS)'
         if: runner.os == 'Linux' || runner.os == 'macOS'
         uses: ammaraskar/gcc-problem-matcher@0.3.0
+      - name: 'Set Up Problem Matcher (Windows)'
+        if: runner.os == 'Windows'
+        uses: ammaraskar/msvc-problem-matcher@0.3.0
+
+      # Build opendds-monitor
       - name: 'Build opendds-monitor (Linux / macOS)'
         if: runner.os == 'Linux' || runner.os == 'macOS'
         shell: bash
@@ -240,6 +242,7 @@ jobs:
           CMAKE_ARGS=""
           if [ '${{ runner.os }}' == 'macOS' ]; then
             # CMAKE_ARGS+=" -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5"
+            export QWT_DIR=$(brew --prefix qwt-qt5)
             CMAKE_ARGS+=" -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)"
           fi
           cmake $CMAKE_ARGS ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
           - windows-2019
           - ubuntu-22.04
           - ubuntu-20.04
+          - macos-14
           - macos-13
-          - macos-12
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,10 +101,13 @@ jobs:
           echo "MPC_ROOT=$GITHUB_WORKSPACE/MPC" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ACE_TAO/ACE/lib:$GITHUB_WORKSPACE/OpenDDS/lib" >> $GITHUB_ENV
           CONFIG_OPTIONS+=" --no-tests --std=c++17 --ipv6 --security"
-          if [ '${{ matrix.runner }}' == 'macos-13' ]; then
-            CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@1.1"
-          else
-            CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@3.0"
+          if [ '${{ runner.os }}' == 'macOS' ]; then
+            if [ '${{ matrix.runner }}' == 'macos-13' ]; then
+              CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@1.1"
+            else
+              ls -la /usr/local/opt
+              CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@3"
+            fi
           fi
           echo "CONFIG_OPTIONS=$CONFIG_OPTIONS" >> $GITHUB_ENV
           export COMPILER_VERSION=$(c++ --version 2>&1 | head -n 1)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,7 +235,8 @@ jobs:
           cd build
           CMAKE_ARGS=""
           if [ '${{ runner.os }}' == 'macOS' ]; then
-            CMAKE_ARGS+=" -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5"
+            # CMAKE_ARGS+=" -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5"
+            CMAKE_ARGS+=" -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)"
           fi
           cmake $CMAKE_ARGS ..
           cmake --build . -t all -t managed_testapp -t unmanaged_testapp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,8 @@ jobs:
             if [ '${{ matrix.runner }}' == 'macos-13' ]; then
               CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@1.1"
             else
-              ls -la /usr/local/opt
-              CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@3"
+              ls -la /usr/local
+              CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/openssl@3"
             fi
           fi
           echo "CONFIG_OPTIONS=$CONFIG_OPTIONS" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,7 @@ jobs:
             if [ '${{ matrix.runner }}' == 'macos-13' ]; then
               CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@1.1"
             else
-              ls -la /usr/local
-              CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/openssl@3"
+              CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=$(brew --prefix openssl)"
             fi
           fi
           echo "CONFIG_OPTIONS=$CONFIG_OPTIONS" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/*
+CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,20 +79,30 @@ if(WIN32)
   list(APPEND SOURCE ddsmon.rc)
 endif(WIN32)
 
-qt_add_resources(RESOURCES ddsmon.qrc)
+if (NOT Qt6_FOUND)
+    qt5_add_resources(RESOURCES ddsmon.qrc)
+else()
+    qt_add_resources(RESOURCES ddsmon.qrc)
+endif()
 
-qt_wrap_cpp(MOC_SOURCE
-  src/graph_page.h
-  src/log_page.h
-  src/main_window.h
-  src/participant_page.h
-  src/participant_table_model.h
-  src/publication_monitor.h
-  src/recorder_dialog.h
-  src/subscription_monitor.h
-  src/table_page.h
-  src/topic_table_model.h
+set(MOC_SOURCE_LIST
+    src/graph_page.h
+    src/log_page.h
+    src/main_window.h
+    src/participant_page.h
+    src/participant_table_model.h
+    src/publication_monitor.h
+    src/recorder_dialog.h
+    src/subscription_monitor.h
+    src/table_page.h
+    src/topic_table_model.h
 )
+
+if (NOT Qt6_FOUND)
+    qt5_wrap_cpp(MOC_SOURCE ${MOC_SOURCE_LIST})
+else()
+    qt_wrap_cpp(MOC_SOURCE ${MOC_SOURCE_LIST})
+endif()
 
 add_executable(monitor
   ${SOURCE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ else()
   set(qt_optional_components DBus)
 endif()
 
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets Gui PrintSupport Svg OpenGL OPTIONAL_COMPONENTS ${qt_optional_components})
+find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core Widgets Gui PrintSupport Svg OpenGL OPTIONAL_COMPONENTS ${qt_optional_components})
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Gui PrintSupport Svg OpenGL OPTIONAL_COMPONENTS ${qt_optional_components})
 
 if(QWT_IS_LOCAL)
   set(QWT_LIBRARY ${PROJECT_SOURCE_DIR}/qwt/lib/qwt$<$<CONFIG:DEBUG>:d>.lib)
@@ -78,9 +79,9 @@ if(WIN32)
   list(APPEND SOURCE ddsmon.rc)
 endif(WIN32)
 
-qt5_add_resources(RESOURCES ddsmon.qrc)
+qt_add_resources(RESOURCES ddsmon.qrc)
 
-qt5_wrap_cpp(MOC_SOURCE
+qt_wrap_cpp(MOC_SOURCE
   src/graph_page.h
   src/log_page.h
   src/main_window.h
@@ -124,13 +125,13 @@ target_compile_options(monitor PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COM
 target_link_libraries(monitor
   OpenDDW
   ${QWT_LIBRARY}
-  Qt5::PrintSupport
-  Qt5::Widgets
-  Qt5::Core
-  Qt5::Gui
-  Qt5::Svg
-  Qt5::OpenGL
-  $<$<NOT:$<PLATFORM_ID:Windows>>:Qt5::DBus>
+  Qt${QT_VERSION_MAJOR}::PrintSupport
+  Qt${QT_VERSION_MAJOR}::Widgets
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Gui
+  Qt${QT_VERSION_MAJOR}::Svg
+  Qt${QT_VERSION_MAJOR}::OpenGL
+  $<$<NOT:$<PLATFORM_ID:Windows>>:Qt${QT_VERSION_MAJOR}::DBus>
 )
 
 target_include_directories(monitor PRIVATE

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -279,7 +279,11 @@ void DDSMonitorMainWindow::parseCmd()
     for (int i = 1; i < argList.count(); i++)
     {
         argString = argList.at(i);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         argString.remove(QRegExp("^-*")); // Remove any - prefix
+#else
+        argString.remove(QRegularExpression("^-*")); // Remove any - prefix
+#endif
 
         // Help!
         if (argString == "h" || argString == "help")

--- a/src/recorder_dialog.cpp
+++ b/src/recorder_dialog.cpp
@@ -3,10 +3,12 @@
 
 #include <QFileDialog>
 #include <QMessageBox>
-#include <QTextCodec>
 #include <QSettings>
 #include <QTime>
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#include <QTextCodec>
+#endif
 
 //------------------------------------------------------------------------------
 RecorderDialog::RecorderDialog(const QString& topicName,
@@ -152,7 +154,11 @@ void RecorderDialog::on_recordButton_clicked()
 
     // Prepare the output stream
     m_outputStream.setDevice(&m_outputFile);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     m_outputStream.setCodec(QTextCodec::codecForName("UTF-8"));
+#else
+    m_outputStream.setEncoding(QStringConverter::Utf8);
+#endif
     m_outputStream.setRealNumberNotation(QTextStream::FixedNotation);
     m_outputStream.setRealNumberPrecision(6);
 

--- a/src/topic_table_model.cpp
+++ b/src/topic_table_model.cpp
@@ -407,7 +407,7 @@ void TopicTableModel::parseData(const std::shared_ptr<OpenDynamicData> data)
         {
             wchar_t tmpValue[2] = { 0, 0 };
             tmpValue[0] = child->getValue<wchar_t>();
-            dataRow->value = ACE_Wide_To_Ascii(tmpValue).char_rep();
+            dataRow->value = QString(ACE_Wide_To_Ascii(tmpValue).char_rep());
             break;
         }
         case CORBA::tk_octet:
@@ -619,14 +619,14 @@ void TopicTableModel::setDataRow(DataRow* const data_row,
     case CORBA::tk_char: {
         CORBA::Char value[2] = { 0, 0 };
         if (check_rc(data->get_char8_value(value[0], id), "get_char8_value failed")) {
-            data_row->value = value;
+            data_row->value = QString(value);
         }
         break;
     }
     case CORBA::tk_wchar: {
         CORBA::WChar value[2] = { 0, 0 };
         if (check_rc(data->get_char16_value(value[0], id), "get_char16_value failed")) {
-            data_row->value = ACE_Wide_To_Ascii(value).char_rep();
+            data_row->value = QString(ACE_Wide_To_Ascii(value).char_rep());
         }
         break;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 project(opendds-monitor-tests VERSION 0.0.1 LANGUAGES CXX)
 
 add_library(test_common INTERFACE)
-target_compile_options(test_common INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wall -Wpedantic -Wno-unused -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-include-dirs -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wstrict-overflow=5 -Wundef -Werror> $<$<CXX_COMPILER_ID:MSVC>: /W4>)
+target_compile_options(test_common INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wall -Wextra -Wpedantic -Wno-unused -Wunused-parameter> $<$<CXX_COMPILER_ID:MSVC>: /W4>)
 if (MSVC)
   target_compile_definitions(test_common INTERFACE _CRT_SECURE_NO_WARNINGS)
 else()


### PR DESCRIPTION
Problem:
 - Build files are not currently set up to build for Qt6
 - A few changes in Qt6 APIs break the build for Qt6

Solution:
 - Expand build coverage to include Qt6
 - Fix build for Qt6 APIs