### PR TITLE
Fix crash on shutdown

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -104,8 +104,16 @@ DDSMonitorMainWindow::DDSMonitorMainWindow() :
 //------------------------------------------------------------------------------
 DDSMonitorMainWindow::~DDSMonitorMainWindow()
 {
-    CommonData::cleanup();
+    for (int i = 0; i < mainTabWidget->count(); i++)
+    {
+        QWidget* removedTab = mainTabWidget->widget(i);
+        mainTabWidget->removeTab(i);
+        removedTab->close();
+        delete removedTab;
+    }
+    mainTabWidget->clear();
 
+    CommonData::cleanup();
     CommonData::m_ddsManager.reset();
     ShutdownDDS();
 }
@@ -233,14 +241,9 @@ void DDSMonitorMainWindow::on_topicTree_itemClicked(QTreeWidgetItem* item, int)
 //------------------------------------------------------------------------------
 void DDSMonitorMainWindow::on_mainTabWidget_tabCloseRequested(int pageIndex)
 {
-    // Don't let the user close the log page
-    if (mainTabWidget->tabText(pageIndex) == "Log")
-    {
-        return;
-    }
-
-    // Don't let the user close the participant page
-    if (mainTabWidget->tabText(pageIndex) == "Participants")
+    // Don't let the user close the log and participant pages
+    const QString pageName = mainTabWidget->tabText(pageIndex);
+    if (pageName == "Log" || pageName == "Participants")
     {
         return;
     }

--- a/src/publication_monitor.cpp
+++ b/src/publication_monitor.cpp
@@ -11,7 +11,7 @@
 PublicationMonitor::PublicationMonitor() : m_dataReader(nullptr)
 {
     DDS::DomainParticipant* domain = CommonData::m_ddsManager->getDomainParticipant();
-    DDS::Subscriber_var subscriber = domain->get_builtin_subscriber() ;
+    DDS::Subscriber_var subscriber = domain->get_builtin_subscriber();
     if (!subscriber)
     {
         std::cerr << "PublicationMonitor: "

--- a/src/table_page.cpp
+++ b/src/table_page.cpp
@@ -15,11 +15,10 @@
 
 
 //------------------------------------------------------------------------------
-TablePage::TablePage(const QString& topicName,
-                     QWidget *parent) :
-                     QWidget(parent),
-                     m_topicName(topicName),
-                     m_refreshTimer(this)
+TablePage::TablePage(const QString& topicName, QWidget *parent) :
+    QWidget(parent),
+    m_topicName(topicName),
+    m_refreshTimer(this)
 {
     setupUi(this);
 

--- a/src/topic_monitor.cpp
+++ b/src/topic_monitor.cpp
@@ -16,14 +16,14 @@
 
 //------------------------------------------------------------------------------
 TopicMonitor::TopicMonitor(const QString& topicName) :
-                           m_topicName(topicName),
-                           m_filter(""),
-                           m_typeCode(nullptr),
-                           m_recorder_listener(OpenDDS::DCPS::make_rch<RecorderListener>(OpenDDS::DCPS::ref(*this))),
-                           m_recorder(nullptr),
-                           m_dr_listener(new DataReaderListenerImpl(*this)),
-                           m_topic(nullptr),
-                           m_paused(false)
+    m_topicName(topicName),
+    m_filter(""),
+    m_typeCode(nullptr),
+    m_recorder_listener(OpenDDS::DCPS::make_rch<RecorderListener>(OpenDDS::DCPS::ref(*this))),
+    m_recorder(nullptr),
+    m_dr_listener(new DataReaderListenerImpl(*this)),
+    m_topic(nullptr),
+    m_paused(false)
 {
     // Make sure we have an information object for this topic
     std::shared_ptr<TopicInfo> topicInfo = CommonData::getTopicInfo(topicName);

--- a/src/topic_monitor.h
+++ b/src/topic_monitor.h
@@ -26,7 +26,6 @@ public:
     /**
      * @brief Constructor for the DDS topic monitor.
      * @param[in] topicName The name of the topic to monitor.
-     * @param[in] extensibility the topic extensibility.
      */
     TopicMonitor(const QString& topicName);
 


### PR DESCRIPTION
- Problem:
OpenDDS shutdown happens before `TopicMonitor` objects are destroyed. `TopicMonitor` object, however, holds a `Recorder` object among other OpenDDS objects. When `TopicMonitor` objects are destroyed, the OpenDDS data needed for the deletion of the `Recorder` objects (and potentially other OpenDDS objects) is no longer valid, causing the crash.

- Solution:
Cleanup the `TopicMonitor` objects before shutting down OpenDDS