### PR TITLE
[Feat] Add filtering support for dynamic data type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 CMakeLists.txt.user
+.vscode/

--- a/src/topic_monitor.h
+++ b/src/topic_monitor.h
@@ -154,6 +154,37 @@ private:
     /// The topic extensibility
     OpenDDS::DCPS::Extensibility m_extensibility;
 
+    // Evaluate a filter on a dynamic data sample.
+    bool evaluateDynamicFilter(DDS::DynamicData_ptr data, const QString &filter);
+
+    // Clean up the filter string by removing whitespace, comment, double spaces, enters, etc.
+    QString cleanFilter(const QString &filter);
+
+    // Evaluate a complex filter expression with AND, OR, NOT operators
+    bool evaluateFilterExpression(DDS::DynamicData_ptr data, const QString &expression);
+
+    // Split expression on a given operator while respecting parentheses
+    QStringList splitOnOperator(const QString &expression, const QString &op);
+
+    // Evaluate a simple comparison (field op value)
+    bool evaluateSimpleComparison(DDS::DynamicData_ptr data, const QString &expression);
+
+    // Evaluate IN and NOT IN operators
+    bool evaluateInOperator(DDS::DynamicData_ptr data, const QString &fieldName, const QString &valueList, bool isNotIn);
+
+    // Evaluate LIKE operator for pattern matching
+    bool evaluateLikeOperator(DDS::DynamicData_ptr data, const QString &fieldName, const QString &pattern);
+
+    // Convert SQL LIKE pattern to regex
+    QString sqlLikeToRegex(const QString &likePattern);
+
+    // Compare the values of a field with the filter value.
+    template <typename T>
+    bool compareValues(const T &fieldValue, const T &filterValue, const QString &op);
+
+    // Compare string values with the filter value.
+    bool compareStrings(const QString &fieldValue, const QString &filterValue, const QString &op);
+
 #if OPENDDS_MAJOR_VERSION == 3 && OPENDDS_MINOR_VERSION >= 24
     struct FilterTypeSupport : OpenDDS::DCPS::TypeSupportImpl {
       FilterTypeSupport(const DynamicMetaStruct& metastruct, OpenDDS::DCPS::Extensibility exten);


### PR DESCRIPTION
PR Split from https://github.com/OpenDDS/opendds-monitor/pull/72

<img width="907" height="585" alt="image" src="https://github.com/user-attachments/assets/fd72213f-fa0d-4b18-9966-6e40d5fcb796" />

This pull request significantly improves the topic filter dialog in the `TablePage` UI and lays the groundwork for more advanced filter expression parsing in the backend. The main change replaces the basic input dialog with a custom, user-friendly filter dialog that supports multi-line editing, provides clear instructions, and adds dedicated buttons for clearing, confirming, or canceling the filter. Additionally, several helper methods are introduced in `TopicMonitor` to support complex filter evaluation, although their implementations are not included in this diff.

**UI/UX Improvements to Topic Filter Dialog:**

* Replaced the simple `QInputDialog` with a custom `QDialog` in `TablePage::on_filterButton_clicked`, featuring a multi-line `QTextEdit` for filter input, detailed instructions, and dedicated "Clear", "OK", and "Cancel" buttons. This makes it easier for users to enter, clear, or cancel filter expressions.
* The filter dialog now pre-populates the input field with the current filter, improving usability.

**Backend Preparation for Advanced Filter Expressions:**

* Added several private helper method declarations to `TopicMonitor` for evaluating and parsing complex filter expressions (e.g., handling SQL-like logic, cleaning input, supporting `IN`, `LIKE`, and comparison operators). These methods will enable more powerful and flexible filtering in the future.

**Dependency Update:**

* Updated the OpenDDW submodule to a newer commit, which may include upstream bug fixes or features.

**Additional Includes for UI Components:**

* Added necessary Qt includes in `table_page.cpp` to support the new dialog and its widgets.