### PR TITLE
[fix] prevent crash for several topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 CMakeLists.txt.user
+.vscode/

--- a/src/topic_monitor.cpp
+++ b/src/topic_monitor.cpp
@@ -87,9 +87,11 @@ TopicMonitor::TopicMonitor(const QString& topicName)
                                             topicInfo->topicQos(),
                                             0,
                                             0);
+
         if (!m_topic)
         {
-            throw std::runtime_error(std::string("Failed to create topic \"") + topicInfo->topicName() + "\"");
+            std::cerr << "Failed to create topic " << topicInfo->topicName() << std::endl;
+            return;
         }
 
         DDS::Subscriber_var subscriber = participant->create_subscriber(topicInfo->subQos(),


### PR DESCRIPTION
Yeah apparently the old code causes the app to unable to open several topic (in not sure why, and it seems to be persistent to that topic), this PR fixed it