### PR TITLE
Fix Unused Open Result Warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
-          vcpkgGitCommitId: 898b728edc5e0d12b50015f9cd18247c4257a3eb
+          vcpkgGitCommitId: 74e6536215718009aae747d86d84b78376bf9e09
           runVcpkgInstall: true
 
       # Set Up Build Environments

--- a/src/table_page.cpp
+++ b/src/table_page.cpp
@@ -258,7 +258,15 @@ void TablePage::on_iniButton_clicked()
 
 
     QFile iniFile(iniPath);
-    iniFile.open(QIODevice::WriteOnly | QIODevice::Text);
+
+    if (!iniFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setText(QString("TablePage::on_iniButton_clicked: Unable to open file '%1' for writing").arg(iniPath));
+        msgBox.exec();
+        return;
+    }
+
     QTextStream out(&iniFile);
 
     out << "[" << m_topicName << "]\n";


### PR DESCRIPTION
Fixes an unused result warning in `table_page.cpp` for more recent versions of Qt.
Also bumps vcpkg commit ID so CI passes again.