### PR TITLE
Fix Shutdown Segfault

### DIFF
--- a/src/dds_data.cpp
+++ b/src/dds_data.cpp
@@ -380,6 +380,11 @@ QVariant CommonData::readValue(const QString& topicName,
                                unsigned int index)
 {
     std::shared_ptr<TopicInfo> topicInfo = getTopicInfo(topicName);
+    if (!topicInfo)
+    {
+        return QVariant();
+    }
+
     if (topicInfo->typeMode() == TypeDiscoveryMode::TypeCode)
     {
         return readMember(topicName, memberName, index);
@@ -392,6 +397,11 @@ QVariant CommonData::readValue(const QString& topicName,
 void CommonData::flushSamples(const QString& topicName)
 {
     std::shared_ptr<TopicInfo> topicInfo = getTopicInfo(topicName);
+    if (!topicInfo)
+    {
+        return;
+    }
+
     if (topicInfo->typeMode() == TypeDiscoveryMode::TypeCode)
     {
         flushStaticSamples(topicName);

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -107,14 +107,13 @@ DDSMonitorMainWindow::DDSMonitorMainWindow() :
 //------------------------------------------------------------------------------
 DDSMonitorMainWindow::~DDSMonitorMainWindow()
 {
-    for (int i = 0; i < mainTabWidget->count(); i++)
+    while (mainTabWidget->count() > 0)
     {
-        QWidget* removedTab = mainTabWidget->widget(i);
-        mainTabWidget->removeTab(i);
+        QWidget* removedTab = mainTabWidget->widget(0);
+        mainTabWidget->removeTab(0);
         removedTab->close();
         delete removedTab;
     }
-    mainTabWidget->clear();
 
     CommonData::cleanup();
     ShutdownDDS();


### PR DESCRIPTION
Problem:
 - Shutdown ordering issues cause potential use of invalid pointers.
 - Tab cleanup used invalid indices when removing tabs.

Solution:
 - Check pointers before use.
 - Remove first tab, delete, repeat.